### PR TITLE
Add uproot to Binder requirements.txt

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,3 +3,4 @@ numpy
 papermill
 pyhf
 scipy
+uproot


### PR DESCRIPTION
https://github.com/scikit-hep/uproot

`uproot` is explicitly needed in the `importxml` Jupyter notebook example